### PR TITLE
fix: getPublicURL works incorrectly in case of unspecified URL

### DIFF
--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -218,7 +218,7 @@ func (m *manager) defaultURL() *url.URL {
 
 func (m *manager) getPublicURL() string {
 	u := m.defaultURL()
-	if u.Host != "" {
+	if u.Port() == "" || len(u.Host) != len(":")+len(u.Port()) {
 		return u.String()
 	}
 	addrs, err := net.InterfaceAddrs()


### PR DESCRIPTION
Signed-off-by: Denis Tingajkin <denis.tingajkin@xored.com>