### PR TITLE
[deployments-k8s#906] Decrease default token timeout to 10m

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -27,5 +27,5 @@ type Config struct {
 	Name             string        `default:"nmgr" desc:"Name of Network service manager"`
 	ListenOn         []url.URL     `default:"unix:///var/lib/networkservicemesh/nsm.io.sock" desc:"url to listen on. tcp:// one will be used a public to register NSM." split_words:"true"`
 	RegistryURL      url.URL       `default:"tcp://localhost:5001" desc:"A NSE registry url to use" split_words:"true"`
-	MaxTokenLifetime time.Duration `default:"24h" desc:"maximum lifetime of tokens" split_words:"true"`
+	MaxTokenLifetime time.Duration `default:"10m" desc:"maximum lifetime of tokens" split_words:"true"`
 }


### PR DESCRIPTION
## Description
Sets default token timeout to `10m`.

## Issue
networkservicemesh/deployments-k8s#906