### PR TITLE
qfix: Add dial timeout for NSMgr

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,4 +29,5 @@ type Config struct {
 	RegistryURL      url.URL       `default:"tcp://localhost:5001" desc:"A NSE registry url to use" split_words:"true"`
 	MaxTokenLifetime time.Duration `default:"10m" desc:"maximum lifetime of tokens" split_words:"true"`
 	LogLevel         string        `default:"INFO" desc:"Log level" split_words:"true"`
+	DialTimeout      time.Duration `default:"1s" desc:"Timeout for the dial the next endpoint" split_words:"true"`
 }

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -108,6 +108,7 @@ func RunNsmgr(ctx context.Context, configuration *config.Config) error {
 		nsmgr.WithName(configuration.Name),
 		nsmgr.WithURL(m.getPublicURL()),
 		nsmgr.WithAuthorizeServer(authorize.NewServer()),
+		nsmgr.WithDialTimeout(configuration.DialTimeout),
 		nsmgr.WithDialOptions(
 			append(opentracing.WithTracingDial(),
 				grpc.WithTransportCredentials(
@@ -116,7 +117,6 @@ func RunNsmgr(ctx context.Context, configuration *config.Config) error {
 					),
 				),
 				grpc.WithDefaultCallOptions(
-					grpc.WaitForReady(true),
 					grpc.PerRPCCredentials(token.NewPerRPCCredentials(spiffejwt.TokenGeneratorFunc(m.source, configuration.MaxTokenLifetime))),
 				),
 				grpcfd.WithChainStreamInterceptor(),


### PR DESCRIPTION
Signed-off-by: denis-tingaikin <denis.tingajkin@xored.com>

## Motivation

NSMgr should be able to iterate over NSEs candidates even in case if one of the candidates is died.