### PR TITLE
qfix: Add net.Dialer with dialTimeout for nsmgr

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,5 +29,5 @@ type Config struct {
 	RegistryURL      url.URL       `default:"tcp://localhost:5001" desc:"A NSE registry url to use" split_words:"true"`
 	MaxTokenLifetime time.Duration `default:"10m" desc:"maximum lifetime of tokens" split_words:"true"`
 	LogLevel         string        `default:"INFO" desc:"Log level" split_words:"true"`
-	DialTimeout      time.Duration `default:"1s" desc:"Timeout for the dial the next endpoint" split_words:"true"`
+	DialTimeout      time.Duration `default:"10ms" desc:"Timeout for the dial the next endpoint" split_words:"true"`
 }

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -116,6 +116,10 @@ func RunNsmgr(ctx context.Context, configuration *config.Config) error {
 						credentials.NewTLS(tlsconfig.MTLSClientConfig(m.source, m.source, tlsconfig.AuthorizeAny())),
 					),
 				),
+				grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
+					network, addr := grpcutils.TargetToNetAddr(s)
+					return (&net.Dialer{Timeout: configuration.DialTimeout}).DialContext(ctx, network, addr)
+				}),
 				grpc.WithDefaultCallOptions(
 					grpc.PerRPCCredentials(token.NewPerRPCCredentials(spiffejwt.TokenGeneratorFunc(m.source, configuration.MaxTokenLifetime))),
 				),

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -116,10 +116,7 @@ func RunNsmgr(ctx context.Context, configuration *config.Config) error {
 						credentials.NewTLS(tlsconfig.MTLSClientConfig(m.source, m.source, tlsconfig.AuthorizeAny())),
 					),
 				),
-				grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
-					network, addr := grpcutils.TargetToNetAddr(s)
-					return (&net.Dialer{Timeout: configuration.DialTimeout}).DialContext(ctx, network, addr)
-				}),
+				grpc.WithBlock(),
 				grpc.WithDefaultCallOptions(
 					grpc.PerRPCCredentials(token.NewPerRPCCredentials(spiffejwt.TokenGeneratorFunc(m.source, configuration.MaxTokenLifetime))),
 				),


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>

## Motivation

Since we are not using a `grpc.WithBlock` option in nsmgr (see at https://github.com/networkservicemesh/sdk/pull/1083)

The grpc is not using our dialTimeout(https://github.com/networkservicemesh/sdk/blob/main/pkg/networkservice/common/dial/client.go#L52) see at 
1. https://github.com/grpc/grpc-go/blob/master/internal/transport/http2_client.go#L173
2. https://github.com/grpc/grpc-go/blob/master/rpc_util.go#L261-L263

So to avoid problems with the long dial we can simply add for nsmgr dialer with a timeout. 

Note: This is required for heal rework https://github.com/networkservicemesh/sdk/pull/1113

##

To reproduce the problem with long dial just run this:

```go
func TestDial2(t *testing.T) {
   ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
   defer cancel()
   cc, err := grpc.DialContext(ctx, "142.251.1.106:53", grpc.WithInsecure())
   if err != nil {
      panic(err.Error())
   }
   if cc == nil {
      panic(cc)
   }
   client := networkservice.NewNetworkServiceClient(cc)
   conn, err := client.Request(context.Background(), &networkservice.NetworkServiceRequest{})
   if err != nil {
      panic(err.Error())
   }
   if conn == nil {
      panic(cc)
   }
}
```