### PR TITLE
[qfix] Increase default dial timeout

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,5 +29,5 @@ type Config struct {
 	RegistryURL      url.URL       `default:"tcp://localhost:5001" desc:"A NSE registry url to use" split_words:"true"`
 	MaxTokenLifetime time.Duration `default:"10m" desc:"maximum lifetime of tokens" split_words:"true"`
 	LogLevel         string        `default:"INFO" desc:"Log level" split_words:"true"`
-	DialTimeout      time.Duration `default:"10ms" desc:"Timeout for the dial the next endpoint" split_words:"true"`
+	DialTimeout      time.Duration `default:"50ms" desc:"Timeout for the dial the next endpoint" split_words:"true"`
 }


### PR DESCRIPTION
Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>

### Motivation
`10ms` is not enough for some integration-tests:
```
...
Nov  2 23:20:28.388[31m [ERRO] [id:45c1d21c-30e1-4630-9560-d18b6cebd910] [name:nsmgr-wc2m2] [type:NetworkService] [0m(23.2)                         failed to dial unix:///proc/1/fd/12: context deadline exceeded span=0d31e57098eb81f0:6609cdd20789f818:68a739c252c5bc0c:1
...
```
Full nsmgr log: [nsmgr-wc2m2.log](https://github.com/networkservicemesh/cmd-nsmgr/files/7465577/nsmgr-wc2m2.log)