### PR TITLE
Increase dial timeout

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,6 @@ type Config struct {
 	RegistryURL                 url.URL       `default:"tcp://localhost:5001" desc:"A NSE registry url to use" split_words:"true"`
 	MaxTokenLifetime            time.Duration `default:"10m" desc:"maximum lifetime of tokens" split_words:"true"`
 	LogLevel                    string        `default:"INFO" desc:"Log level" split_words:"true"`
-	DialTimeout                 time.Duration `default:"50ms" desc:"Timeout for the dial the next endpoint" split_words:"true"`
+	DialTimeout                 time.Duration `default:"100ms" desc:"Timeout for the dial the next endpoint" split_words:"true"`
 	ForwarderNetworkServiceName string        `default:"forwarder" desc:"the default service name for forwarder discovering" split_words:"true"`
 }


### PR DESCRIPTION
Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>

`50 ms` is not enough for some cases. 
For example, we caught it on `dial.Close()`:
```
...
Nov 19 10:58:10.566[37m [TRAC] [id:0eafd1f2-ecfa-408e-9110-afbfbbcfe96c] [name:nsmgr-42wfj] [type:NetworkService] [0m(23)                       ⎆ sdk/pkg/networkservice/common/dial/dialClient.Close() span=08facc14b33840b5:1189cf3b633a1bb6:130bab6676d637ae:1
Nov 19 10:58:10.642[37m [TRAC] [id:0eafd1f2-ecfa-408e-9110-afbfbbcfe96c] [name:nsmgr-42wfj] [type:NetworkService] [0m(24)                        ⎆ sdk/pkg/networkservice/common/mechanisms/recvfd/recvFDClient.Close() span=08facc14b33840b5:39e0be67363268f5:1189cf3b633a1bb6:1
...
```