### PR TITLE
Update configuration for turning profiling on/off

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ docker build .
 * `NSM_OPEN_TELEMETRY_ENDPOINT`        - OpenTelemetry Collector Endpoint (default: "otel-collector.observability.svc.cluster.local:4317")
 * `NSM_METRICS_EXPORT_INTERVAL`        - interval between mertics exports (default: "10s")
 * `NSM_PPROF_ENABLED`                  - is pprof enabled (default: "false")
-* `NSM_PPROF_PORT`                     - pprof port (default: "6060")
+* `NSM_PPROF_LISTEN_ON`                - pprof URL to ListenAndServe (default: "localhost:6060")
 
 # Testing
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/edwarnicke/serialize v1.0.7
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/networkservicemesh/api v1.13.1-0.20240424210452-d0df98851760
-	github.com/networkservicemesh/sdk v0.5.1-0.20240808113433-ce2c8f56bdd3
+	github.com/networkservicemesh/sdk v0.5.1-0.20240812103952-7e0cf2c383fb
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spiffe/go-spiffe/v2 v2.1.7
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -104,8 +104,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfr
 github.com/miekg/dns v1.1.50 h1:DQUfb9uc6smULcREF09Uc+/Gd46YWqJd5DbpPE9xkcA=
 github.com/networkservicemesh/api v1.13.1-0.20240424210452-d0df98851760 h1:EaWGgdwbUP404Hlee80R+jSxgzjOh/tW5Fm4/9NE4B0=
 github.com/networkservicemesh/api v1.13.1-0.20240424210452-d0df98851760/go.mod h1:B8FmS3XZ7NZY7ZEtdcNg2NHYppDHlr4kl4eecdZN9eI=
-github.com/networkservicemesh/sdk v0.5.1-0.20240808113433-ce2c8f56bdd3 h1:EukdHtlzP75dfF3vG6kukJ0oqBhzxZKOlbKP4rAquhg=
-github.com/networkservicemesh/sdk v0.5.1-0.20240808113433-ce2c8f56bdd3/go.mod h1:soFR6Mg5LTVvEI0zXNcbWoBnn4hqUK7ItZBQJ3Jbszo=
+github.com/networkservicemesh/sdk v0.5.1-0.20240812103952-7e0cf2c383fb h1:p+JeHErfPxRMfF/RF2Dzx23Nr1Q5MQxvS4tvRO7S0X0=
+github.com/networkservicemesh/sdk v0.5.1-0.20240812103952-7e0cf2c383fb/go.mod h1:soFR6Mg5LTVvEI0zXNcbWoBnn4hqUK7ItZBQJ3Jbszo=
 github.com/open-policy-agent/opa v0.44.0 h1:sEZthsrWBqIN+ShTMJ0Hcz6a3GkYsY4FaB2S/ou2hZk=
 github.com/open-policy-agent/opa v0.44.0/go.mod h1:YpJaFIk5pq89n/k72c1lVvfvR5uopdJft2tMg1CW/yU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,5 +38,5 @@ type Config struct {
 	OpenTelemetryEndpoint       string        `default:"otel-collector.observability.svc.cluster.local:4317" desc:"OpenTelemetry Collector Endpoint" split_words:"true"`
 	MetricsExportInterval       time.Duration `default:"10s" desc:"interval between mertics exports" split_words:"true"`
 	PprofEnabled                bool          `default:"false" desc:"is pprof enabled" split_words:"true"`
-	PprofPort                   uint16        `default:"6060" desc:"pprof port" split_words:"true"`
+	PprofListenOn               string        `default:"localhost:6060" desc:"pprof URL to ListenAndServe" split_words:"true"`
 }

--- a/internal/imports/imports_linux.go
+++ b/internal/imports/imports_linux.go
@@ -38,7 +38,7 @@ import (
 	_ "github.com/networkservicemesh/sdk/pkg/tools/log/logruslogger"
 	_ "github.com/networkservicemesh/sdk/pkg/tools/monitorconnection/authorize"
 	_ "github.com/networkservicemesh/sdk/pkg/tools/opentelemetry"
-	_ "github.com/networkservicemesh/sdk/pkg/tools/pprof"
+	_ "github.com/networkservicemesh/sdk/pkg/tools/pprofutils"
 	_ "github.com/networkservicemesh/sdk/pkg/tools/spiffejwt"
 	_ "github.com/networkservicemesh/sdk/pkg/tools/spire"
 	_ "github.com/networkservicemesh/sdk/pkg/tools/token"

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
 	"github.com/networkservicemesh/sdk/pkg/tools/log/logruslogger"
 	"github.com/networkservicemesh/sdk/pkg/tools/opentelemetry"
-	"github.com/networkservicemesh/sdk/pkg/tools/pprof"
+	"github.com/networkservicemesh/sdk/pkg/tools/pprofutils"
 )
 
 func main() {
@@ -91,7 +91,7 @@ func main() {
 
 	// Configure pprof
 	if cfg.PprofEnabled {
-		go pprof.Init(ctx, cfg.PprofPort)
+		go pprofutils.ListenAndServe(ctx, cfg.PprofListenOn)
 	}
 
 	err = manager.RunNsmgr(ctx, cfg)


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Updated configuration for turning profiling on/off after sdk update.


## Issue link
https://github.com/networkservicemesh/deployments-k8s/issues/12045


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [x] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI